### PR TITLE
Exit early if it errors with too-few-machines, no point in trying the rest

### DIFF
--- a/ensure_enough.py
+++ b/ensure_enough.py
@@ -410,8 +410,13 @@ class StateManagement:
                     fault = self.os_command(['server', 'show', server['ID']]).get('fault', {'message': '<error>'})
                 else:
                     fault = {'message': "Unknown"}
+
                 logging.error('Failed to launch %s: %s', server['Name'], fault['message'])
                 self.brutally_terminate(server)
+
+                if 'There are not enough hosts available' in fault['message']:
+                    logging.warning('Skipping launch attempt for remaining machines due to too-few-hosts error.')
+                    break
             else:
                 logging.info('Launched. %s (state=%s)', server, server['Status'])
 

--- a/ensure_enough.py
+++ b/ensure_enough.py
@@ -471,11 +471,14 @@ class StateManagement:
                 # Galaxy-net must be the used network, maybe this check is extraneous
                 # but better to only work on things we know are safe to work on.
 
-                # TODO: This changed formats, printing it and someone can know the DS to fix it next time. I'm guessing it'll just be `server["Networks"].keys()`
-                print(server['Networks'])
+                # This changed formats, i guess due to versions of python-openstackclient?
+                if isinstance(server['Networks'], dict):
+                    netz = server['Networks']
+                else:
+                    # 99% sure this'll work (:
+                    netz = { x.split('=')[0]: x.split('=')[1] for x in server['Networks'].split(',') }
 
-                netz = [x.split('=')[0] for x in server['Networks'].split(',')]
-                if self.config['network'] not in netz:
+                if self.config['network'] not in netz.keys():
                     if server['Status'] == 'ERROR':
                         self.brutally_terminate(server)
                         continue


### PR DESCRIPTION
As it is not a transient error. Prevents this nonsense:


```
00:07:40.968 INFO:root:launching vgcnbwc-worker-c125m425-9677 (c1.c125m425)
00:07:59.103 ERROR:root:Failed to launch vgcnbwc-worker-c125m425-9677: No valid host was found. There are not enough hosts available.
00:07:59.103 INFO:root:Brutally terminating vgcnbwc-worker-c125m425-9677
00:08:02.828 INFO:root:b''
00:08:02.828 INFO:root:launching vgcnbwc-worker-c125m425-8780 (c1.c125m425)

00:08:19.311 ERROR:root:Failed to launch vgcnbwc-worker-c125m425-8780: No valid host was found. There are not enough hosts available.
00:08:19.311 INFO:root:Brutally terminating vgcnbwc-worker-c125m425-8780

00:08:22.870 INFO:root:b''
00:08:22.870 INFO:root:launching vgcnbwc-worker-c125m425-4408 (c1.c125m425)

00:08:42.804 ERROR:root:Failed to launch vgcnbwc-worker-c125m425-4408: No valid host was found. There are not enough hosts available.
00:08:42.804 INFO:root:Brutally terminating vgcnbwc-worker-c125m425-4408

00:08:46.832 INFO:root:b''
00:08:46.832 INFO:root:launching vgcnbwc-worker-c125m425-9810 (c1.c125m425)

00:09:09.845 ERROR:root:Failed to launch vgcnbwc-worker-c125m425-9810: No valid host was found. There are not enough hosts available.
00:09:09.845 INFO:root:Brutally terminating vgcnbwc-worker-c125m425-9810
```

Also this includes a workaround for a crash that was happening, whereby `server['Networks']` started returning a `dict` instead of a `str`