### PR TITLE
Update GCC training allocation

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -217,5 +217,5 @@ deployment:
     count: 5
     flavor: c1.c28m225
     start: 2022-07-08
-    end: 2022-07-09
+    end: 2022-07-20
     group: training-gcc2022


### PR DESCRIPTION
Helena got resources this morning for the GCC online training day (July 8). Later today, Assunta requested resources for the in-person training week, only a few days after. So I've thought that we could merge both into just one request and share the link for all the training activities during GCC. Does this sound like a good idea?