### PR TITLE
Adjusting Galaxy compute resources

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -28,10 +28,10 @@ pubkeys:
 nodes_inventory:
   c1.c28m225: 7
   c1.c28m475: 19
-  c1.c36m100: 31
+  c1.c36m100: 32
   c1.c36m225: 15
   c1.c36m900: 1
-  c1.c36m975: 14
+  c1.c36m975: 13
   c1.c60m1975: 1
   c1.c125m225: 12
   c1.c125m425: 36
@@ -96,7 +96,7 @@ deployment:
       mem_limit_policy: hard
       mem_reserved_size: 2048
   worker-c36m100:
-    count: 21 #31
+    count: 22 #32
     flavor: c1.c36m100
     group: compute
     docker_ready: true
@@ -129,7 +129,7 @@ deployment:
       mem_limit_policy: soft
       mem_reserved_size: 2048
   worker-c36m975:
-    count: 14 #14
+    count: 13 #13
     flavor: c1.c36m975
     group: compute
     docker_ready: true


### PR DESCRIPTION
I have adjusted the following flavours node count to offer more RAM to a user's VM
1. I have reduced the total count of this flavour `c1.c36m975` (36 cores, 975 GB RAM) from `14` to `13` and also reduced the worker node count
2. I have increased the `c1.c36m100` (36 cores, 100 GB RAM) count from `31` to `32` and also increased the `worker-c36m100` compute group from `21` to `22`.
 
This balancing was done such that the rest of the resources from the reduced flavour node is also utilized for `compute` workers.