### PR TITLE
Remove redundant training resource def and change flavor

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -246,31 +246,25 @@ deployment:
     group: training-popgen-microbe
   training-uni-:
     count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-04-18
     end: 2023-05-12
     group: training-uni-zurich
   training-sfb1:
     count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-04-24
     end: 2023-04-28
     group: training-sfb1425-2023
   training-heh-:
     count: 1
-    flavor: c.c32m240
-    start: 2023-05-01
-    end: 2023-05-06
-    group: training-heh-annot
-  training-heh-:
-    count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-05-01
     end: 2023-05-06
     group: training-heh-annot
   training-ucph:
     count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-04-19
     end: 2023-04-19
     group: training-ucph-enra


### PR DESCRIPTION
The build is failing due to non-existent flavor (`c.c32m240`) introduced in PR #189. This PR changes the flavor from `c.c32m240` to `c1.c28m225` (this flavor is used by other training VMs)