### PR TITLE
change training flavor: c.c32m240 to c1.c28m225

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -196,7 +196,7 @@ deployment:
     start: 2023-03-07
     end: 2023-07-11
     group: training-ruas-skarp-mls
-  training-smor:
+  training-smorinst:
     count: 1
     flavor: c1.c28m225
     start: 2023-05-10

--- a/resources.yaml
+++ b/resources.yaml
@@ -198,43 +198,43 @@ deployment:
     group: training-ruas-skarp-mls
   training-smor:
     count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-05-10
     end: 2023-05-20
     group: training-smorg3-instructors
   training-smor:
     count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-05-22
     end: 2023-05-26
     group: training-smorgasbord3
   training-aiad:
     count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-05-17
     end: 2023-05-17
     group: training-aiadl2023
   training-univ:
     count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-05-15
     end: 2023-05-19
     group: training-universityofsuffolk
   training-szeg:
     count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-05-30
     end: 2023-05-31
     group: training-szeged2023
   training-fair:
     count: 1
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-05-16
     end: 2023-05-17
     group: training-fair-ease-galaxy
   training-erga:
     count: 2
-    flavor: c.c32m240
+    flavor: c1.c28m225
     start: 2023-05-18
     end: 2023-05-26
     group: training-erga-pt-assembly


### PR DESCRIPTION
flavor `c.c32m240` does not exist and this breaks the build jobs. So I have moved all training flavors to `c1.c28m225` the one which was always used for training (for example in: `training-ruas`).