### PR TITLE
Reduce c1.c36m100 node count

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -28,7 +28,7 @@ pubkeys:
 nodes_inventory:
   c1.c28m225: 7
   c1.c28m475: 19
-  c1.c36m100: 31
+  c1.c36m100: 30
   c1.c36m225: 15
   c1.c36m900: 1
   c1.c36m975: 14
@@ -96,7 +96,7 @@ deployment:
       mem_limit_policy: hard
       mem_reserved_size: 2048
   worker-c36m100:
-    count: 21 #31
+    count: 20 #30
     flavor: c1.c36m100
     group: compute
     docker_ready: true


### PR DESCRIPTION
A worker VM of this flavor is already drained so we can offer a VM for Anup (see this [PR in infrastructure repo](https://github.com/usegalaxy-eu/infrastructure/pull/168)).