### PR TITLE
Update flavors. New flavors have 50G disk space.

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -26,16 +26,16 @@ pubkeys:
   - "AAAAB3NzaC1yc2EAAAABIwAAAQEAuSG1VOumQhbJfOyalJjS4lPC8eeeL02ld/VI2BFApyMfwbB1QxehY3lMBXt/cBTzqU3MxgJQVzNr/AgjHa5rKn2hSGMfKAdaX2tG686k715bBjRm9rJNhmc8KSH9tVS35M0HwRXMfiGvSmb5qJ6utWRZe6RM2JMIbqqI5Oc4tbzPPVKk1+yvT1JdYuyqAOp2yvQbOqKaXmqOhPdPNaJZMI4o+UHmmb8FH6OTDY27G7X7u07ZPwVi1j+6ZFVMQZqg1RhUdg9kmHpHwMX7P6NcD4G9GsISHIh92eva9xgWYGiS0wUsmOWTNgAzzsfRZjMFep+jB2wup6QN7XpMw97eTw=="
 
 nodes_inventory:
-  c1.c28m225: 7
-  c1.c28m475: 19
-  c1.c36m100: 30
-  c1.c36m225: 15
-  c1.c36m900: 1
-  c1.c36m975: 14
-  c1.c60m1975: 1
-  c1.c125m225: 12
-  c1.c125m425: 36
-  g1.c7m20g1: 8
+  c1.c28m225d50: 7
+  c1.c28m475d50: 19
+  c1.c36m100d50: 30
+  c1.c36m225d50: 15
+  c1.c36m900d50: 1
+  c1.c36m975d50: 14
+  c1.c60m1975d50: 1
+  c1.c125m225d50: 12
+  c1.c125m425d50: 36
+  g1.c7m20g1d50: 8
 
 deployment:
   worker-maintenance:
@@ -48,7 +48,7 @@ deployment:
     group: fast-turnaround
   worker-fetch:
     count: 1
-    flavor: c1.c36m100
+    flavor: c1.c36m100d50
     group: upload
   worker-metadata:
     count: 1
@@ -59,23 +59,23 @@ deployment:
       mem_reserved_size: 1024
   worker-interactive:
     count: 8 #8
-    flavor: c1.c36m100
+    flavor: c1.c36m100d50
     group: interactive
     docker_ready: true
     secure_ready: true
     volume:
       size: 1024
       type: default
-#  worker-mothur:
-#    count: 3
-#    flavor: c1.c28m475
-#    group: compute_mothur
-#    cgroups:
-#      mem_limit_policy: hard
-#      mem_reserved_size: 2048
+  #  worker-mothur:
+  #    count: 3
+  #    flavor: c1.c28m475d50
+  #    group: compute_mothur
+  #    cgroups:
+  #      mem_limit_policy: hard
+  #      mem_reserved_size: 2048
   worker-c28m475:
     count: 12 #19
-    flavor: c1.c28m475
+    flavor: c1.c28m475d50
     group: compute
     docker_ready: true
     volume:
@@ -86,7 +86,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c28m225:
     count: 0 #7
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     group: compute_test
     docker_ready: true
     volume:
@@ -97,7 +97,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c36m100:
     count: 20 #30
-    flavor: c1.c36m100
+    flavor: c1.c36m100d50
     group: compute
     docker_ready: true
     volume:
@@ -108,7 +108,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c36m225:
     count: 15 #15
-    flavor: c1.c36m225
+    flavor: c1.c36m225d50
     group: compute
     docker_ready: true
     volume:
@@ -118,8 +118,8 @@ deployment:
       mem_limit_policy: hard
       mem_reserved_size: 2048
   worker-c36m900:
-    count: 1 #1 it's a c1.c36m975 host with probably a faulty memory bank
-    flavor: c1.c36m900
+    count: 1 #1 it's a c1.c36m975d50 host with probably a faulty memory bank
+    flavor: c1.c36m900d50
     group: compute
     docker_ready: true
     volume:
@@ -130,7 +130,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c36m975:
     count: 14 #14
-    flavor: c1.c36m975
+    flavor: c1.c36m975d50
     group: compute
     docker_ready: true
     volume:
@@ -141,7 +141,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c64m2:
     count: 1 #1
-    flavor: c1.c60m1975
+    flavor: c1.c60m1975d50
     group: compute
     docker_ready: true
     volume:
@@ -149,7 +149,7 @@ deployment:
       type: default
   worker-c125m225:
     count: 12 #12
-    flavor: c1.c125m225
+    flavor: c1.c125m225d50
     group: compute
     docker_ready: true
     volume:
@@ -160,7 +160,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c125m425:
     count: 36 #36
-    flavor: c1.c125m425
+    flavor: c1.c125m425d50
     group: compute
     docker_ready: true
     volume:
@@ -171,7 +171,7 @@ deployment:
       mem_reserved_size: 2048
   worker-gpu:
     count: 8 #16
-    flavor: g1.c7m20g1
+    flavor: g1.c7m20g1d50
     group: compute_gpu
     gpu_ready: true
     docker_ready: true
@@ -184,52 +184,52 @@ deployment:
       mem_reserved_size: 1024
 
   # Training
-#  training-bio0:
-#    count: 1
-#    flavor: c1.c28m225
-#    start: 2022-10-13
-#    end: 2023-12-02
-#    group: training-bio00058m
+  #  training-bio0:
+  #    count: 1
+  #    flavor: c1.c28m225d50
+  #    start: 2022-10-13
+  #    end: 2023-12-02
+  #    group: training-bio00058m
   training-ruas:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-03-07
     end: 2023-07-11
     group: training-ruas-skarp-mls
 
   training-afri:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-06-26
     end: 2023-06-26
     group: training-africacd-june2023
   training-cclc:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-07-25
     end: 2023-07-25
     group: training-cclcm23
   training-hd-m:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-08-03
     end: 2023-08-04
     group: training-hd-mia2023
   training-gsc2:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-08-07
     end: 2023-08-11
     group: training-gsc23-bangkok-mgnify
   training-mgc-:
     count: 3
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-08-29
     end: 2023-08-30
     group: training-mgc-ngs-2023
   training-bme-:
     count: 2
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-08-29
     end: 2023-08-30
     group: training-bme-certh

--- a/schema.yaml
+++ b/schema.yaml
@@ -64,17 +64,17 @@ mapping:
                         type: str
                         required: true
                         enum:
-                            - c1.c28m225
-                            - c1.c28m475
-                            - c1.c36m100
-                            - c1.c36m225
-                            - c1.c36m900
-                            - c1.c36m975
-                            - c1.c60m1975
-                            - c1.c125m225
-                            - c1.c125m425
-                            - g1.c36m100g1
-                            - g1.c7m20g1
+                            - c1.c28m225d50
+                            - c1.c28m475d50
+                            - c1.c36m100d50
+                            - c1.c36m225d50
+                            - c1.c36m900d50
+                            - c1.c36m975d50
+                            - c1.c60m1975d50
+                            - c1.c125m225d50
+                            - c1.c125m425d50
+                            - g1.c36m100g1d50
+                            - g1.c7m20g1d50
                             - m1.large
                             - m1.medium
                             - m1.nano


### PR DESCRIPTION
New flavors have the suffix `d50`. Old flavors are also retained for backward compatibility. An in-place update was not possible it seems, so new flavors had to be created.