### PR TITLE
Fix flavors and over provisioning

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -29,16 +29,16 @@ pubkeys:
   - "AAAAB3NzaC1yc2EAAAABIwAAAQEAuSG1VOumQhbJfOyalJjS4lPC8eeeL02ld/VI2BFApyMfwbB1QxehY3lMBXt/cBTzqU3MxgJQVzNr/AgjHa5rKn2hSGMfKAdaX2tG686k715bBjRm9rJNhmc8KSH9tVS35M0HwRXMfiGvSmb5qJ6utWRZe6RM2JMIbqqI5Oc4tbzPPVKk1+yvT1JdYuyqAOp2yvQbOqKaXmqOhPdPNaJZMI4o+UHmmb8FH6OTDY27G7X7u07ZPwVi1j+6ZFVMQZqg1RhUdg9kmHpHwMX7P6NcD4G9GsISHIh92eva9xgWYGiS0wUsmOWTNgAzzsfRZjMFep+jB2wup6QN7XpMw97eTw=="
 
 nodes_inventory:
-  c1.c28m225: 7
-  c1.c28m475: 19
-  c1.c36m100: 30
-  c1.c36m225: 15
-  c1.c36m900: 1
-  c1.c36m975: 14
-  c1.c60m1975: 1
-  c1.c125m225: 12
-  c1.c125m425: 36
-  g1.c7m20g1: 8
+  c1.c28m225d50: 7
+  c1.c28m475d50: 19
+  c1.c36m100d50: 30
+  c1.c36m225d50: 15
+  c1.c36m900d50: 1
+  c1.c36m975d50: 14
+  c1.c60m1975d50: 1
+  c1.c120m225d50: 12
+  c1.c120m425d50: 36
+  g1.c7m20g1d50: 8
 
 deployment:
   worker-maintenance:
@@ -51,7 +51,7 @@ deployment:
     group: fast-turnaround
   worker-fetch:
     count: 1
-    flavor: c1.c36m100
+    flavor: c1.c36m100d50
     group: upload
   worker-metadata:
     count: 1
@@ -62,23 +62,23 @@ deployment:
       mem_reserved_size: 1024
   worker-interactive:
     count: 8 #8
-    flavor: c1.c36m100
+    flavor: c1.c36m100d50
     group: interactive
     docker_ready: true
     secure_ready: true
     volume:
       size: 1024
       type: default
-#  worker-mothur:
-#    count: 3
-#    flavor: c1.c28m475
-#    group: compute_mothur
-#    cgroups:
-#      mem_limit_policy: hard
-#      mem_reserved_size: 2048
+  #  worker-mothur:
+  #    count: 3
+  #    flavor: c1.c28m475d50
+  #    group: compute_mothur
+  #    cgroups:
+  #      mem_limit_policy: hard
+  #      mem_reserved_size: 2048
   worker-c28m475:
     count: 12 #19
-    flavor: c1.c28m475
+    flavor: c1.c28m475d50
     group: compute
     docker_ready: true
     volume:
@@ -89,7 +89,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c28m225:
     count: 0 #7
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     group: compute_test
     docker_ready: true
     volume:
@@ -100,7 +100,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c36m100:
     count: 20 #30
-    flavor: c1.c36m100
+    flavor: c1.c36m100d50
     group: compute
     docker_ready: true
     volume:
@@ -111,7 +111,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c36m225:
     count: 15 #15
-    flavor: c1.c36m225
+    flavor: c1.c36m225d50
     group: compute
     docker_ready: true
     volume:
@@ -121,8 +121,8 @@ deployment:
       mem_limit_policy: hard
       mem_reserved_size: 2048
   worker-c36m900:
-    count: 1 #1 it's a c1.c36m975 host with probably a faulty memory bank
-    flavor: c1.c36m900
+    count: 1 #1 it's a c1.c36m975d50 host with probably a faulty memory bank
+    flavor: c1.c36m900d50
     group: compute
     docker_ready: true
     volume:
@@ -133,7 +133,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c36m975:
     count: 14 #14
-    flavor: c1.c36m975
+    flavor: c1.c36m975d50
     group: compute
     docker_ready: true
     volume:
@@ -144,7 +144,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c64m2:
     count: 1 #1
-    flavor: c1.c60m1975
+    flavor: c1.c60m1975d50
     group: compute
     docker_ready: true
     volume:
@@ -152,7 +152,7 @@ deployment:
       type: default
   worker-c125m225:
     count: 12 #12
-    flavor: c1.c125m225
+    flavor: c1.c120m225d50
     group: compute
     docker_ready: true
     volume:
@@ -163,7 +163,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c125m425-alma:
     count: 2 #36
-    flavor: c1.c125m425
+    flavor: c1.c120m425d50
     group: compute
     docker_ready: true
     alma_ready: true
@@ -175,7 +175,7 @@ deployment:
       mem_reserved_size: 2048
   worker-c125m425:
     count: 34 #36
-    flavor: c1.c125m425
+    flavor: c1.c120m425d50
     group: compute
     docker_ready: true
     volume:
@@ -186,7 +186,7 @@ deployment:
       mem_reserved_size: 2048
   worker-gpu:
     count: 8 #16
-    flavor: g1.c7m20g1
+    flavor: g1.c7m20g1d50
     group: compute_gpu
     gpu_ready: true
     docker_ready: true
@@ -199,70 +199,70 @@ deployment:
       mem_reserved_size: 1024
 
   # Training
-#  training-bio0:
-#    count: 1
-#    flavor: c1.c28m225
-#    start: 2022-10-13
-#    end: 2023-12-02
-#    group: training-bio00058m
+  #  training-bio0:
+  #    count: 1
+  #    flavor: c1.c28m225d50
+  #    start: 2022-10-13
+  #    end: 2023-12-02
+  #    group: training-bio00058m
   training-ruas:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-03-07
     end: 2023-07-11
     group: training-ruas-skarp-mls
 
   training-cclc:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-07-25
     end: 2023-07-25
     group: training-cclcm23
   training-hd-m:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-08-03
     end: 2023-08-04
     group: training-hd-mia2023
   training-gsc2:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-08-07
     end: 2023-08-11
     group: training-gsc23-bangkok-mgnify
   training-mgc-:
     count: 3
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-08-29
     end: 2023-08-30
     group: training-mgc-ngs-2023
   training-bme-:
     count: 2
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-08-29
     end: 2023-08-30
     group: training-bme-certh
   training-omit:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-07-05
     end: 2023-07-06
     group: training-omitreen-rna-seq
   training-ur-s:
     count: 3
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-07-24
     end: 2023-07-28
     group: training-ur-ss23
   training-frj1:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-07-17
     end: 2023-07-21
     group: training-fr-july17
   training-frj2:
     count: 1
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-07-24
     end: 2023-07-28
     group: training-fr-july24

--- a/resources.yaml
+++ b/resources.yaml
@@ -37,7 +37,8 @@ nodes_inventory:
   c1.c36m975d50: 14
   c1.c60m1975d50: 1
   c1.c120m225d50: 12
-  c1.c120m425d50: 36
+  c1.c120m425d50: 22
+  c1.c125m425d50: 16
   g1.c7m20g1d50: 8
 
 deployment:
@@ -150,7 +151,7 @@ deployment:
     volume:
       size: 1024
       type: default
-  worker-c125m225:
+  worker-c120m225:
     count: 12 #12
     flavor: c1.c120m225d50
     group: compute
@@ -161,8 +162,8 @@ deployment:
     cgroups:
       mem_limit_policy: hard
       mem_reserved_size: 2048
-  worker-c125m425-alma:
-    count: 2 #36
+  worker-c120m425-alma:
+    count: 2 #22
     flavor: c1.c120m425d50
     group: compute
     docker_ready: true
@@ -173,9 +174,20 @@ deployment:
     cgroups:
       mem_limit_policy: hard
       mem_reserved_size: 2048
-  worker-c125m425:
-    count: 34 #36
+  worker-c120m425:
+    count: 20 #22
     flavor: c1.c120m425d50
+    group: compute
+    docker_ready: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: hard
+      mem_reserved_size: 2048
+  worker-c125m425:
+    count: 16 #16
+    flavor: c1.c125m425d50
     group: compute
     docker_ready: true
     volume:

--- a/schema.yaml
+++ b/schema.yaml
@@ -70,17 +70,17 @@ mapping:
                         type: str
                         required: true
                         enum:
-                            - c1.c28m225
-                            - c1.c28m475
-                            - c1.c36m100
-                            - c1.c36m225
-                            - c1.c36m900
-                            - c1.c36m975
-                            - c1.c60m1975
-                            - c1.c125m225
-                            - c1.c125m425
-                            - g1.c36m100g1
-                            - g1.c7m20g1
+                            - c1.c28m225d50
+                            - c1.c28m475d50
+                            - c1.c36m100d50
+                            - c1.c36m225d50
+                            - c1.c36m900d50
+                            - c1.c36m975d50
+                            - c1.c60m1975d50
+                            - c1.c120m225d50
+                            - c1.c120m425d50
+                            - g1.c36m100g1d50
+                            - g1.c7m20g1d50
                             - m1.large
                             - m1.medium
                             - m1.nano

--- a/schema.yaml
+++ b/schema.yaml
@@ -79,6 +79,7 @@ mapping:
                             - c1.c60m1975d50
                             - c1.c120m225d50
                             - c1.c120m425d50
+                            - c1.c125m425d50
                             - g1.c36m100g1d50
                             - g1.c7m20g1d50
                             - m1.large


### PR DESCRIPTION
1. add d50 suffix; 50G root disk
2. Overprovisioning on n46* nodes fix: `c1.c125m225` is now `c1.c120m225` and new flavor `c1.c120m425`
3. The flavor `c1.c125m425` is now restricted to run only on n38* nodes
4. So, the VM count due to the above changes has been adjusted.

This fixes the failing Jenkins project as well (the flavor `c1.c125m225` was removed due to the fix)
I have updated the machines operations page ([refer commit](https://github.com/usegalaxy-eu/operations/commit/b112ae3df2753da3cee9e50a3fade4c7f8a4d3fe))