### PR TITLE
Fix training flavor name

### DIFF
--- a/add-training.sh
+++ b/add-training.sh
@@ -5,7 +5,7 @@ export LC_NUMERIC="en_US.UTF-8"
 if ([ $# -lt 5 ]); then
     echo "Usage:"
     echo
-    echo "  $0 <training-identifier> <vm-size (e.g. c.c32m240)> <vm-count> <start in YYYY-mm-dd> <end in YYYY-mm-dd> [--donotautocommitpush]"
+    echo "  $0 <training-identifier> <vm-size (e.g. c1.c28m225d50)> <vm-count> <start in YYYY-mm-dd> <end in YYYY-mm-dd> [--donotautocommitpush]"
     echo
     exit 1;
 fi

--- a/resources.yaml
+++ b/resources.yaml
@@ -280,7 +280,7 @@ deployment:
     group: training-fr-july24
   training-gcc2:
     count: 3
-    flavor: c1.c28m225
+    flavor: c1.c28m225d50
     start: 2023-07-13
     end: 2023-07-13
     group: training-gcc23-vgp


### PR DESCRIPTION
@bgruening please use the following flavor `c1.c28m225d50` for training VMs. The old flavors are removed from schema so using old flavors will break Jenkins.