### PR TITLE
New flavor adjustments after GPU infra maintenance

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -31,15 +31,18 @@ pubkeys:
 nodes_inventory:
   c1.c28m225d50: 7
   c1.c28m475d50: 19
-  c1.c36m100d50: 30
+  c1.c36m100d50: 32
   c1.c36m225d50: 15
   c1.c36m900d50: 1
-  c1.c36m975d50: 14
+  c1.c36m975d50: 8
   c1.c60m1975d50: 1
   c1.c120m225d50: 12
   c1.c120m425d50: 22
   c1.c125m425d50: 16
-  g1.c7m20g1d50: 8
+  c1.c28m935d50: 4
+  c1.c28m875d50: 2
+  g1.c14m40g1d50: 4
+  g1.c8m40g1d50: 4
 
 deployment:
   worker-maintenance:
@@ -100,7 +103,7 @@ deployment:
       mem_limit_policy: hard
       mem_reserved_size: 2048
   worker-c36m100:
-    count: 20 #30
+    count: 22 #32
     flavor: c1.c36m100d50
     group: compute
     docker_ready: true
@@ -133,8 +136,30 @@ deployment:
       mem_limit_policy: soft
       mem_reserved_size: 2048
   worker-c36m975:
-    count: 14 #14
+    count: 8 #8
     flavor: c1.c36m975d50
+    group: compute
+    docker_ready: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: soft
+      mem_reserved_size: 2048
+  worker-c28m935:
+    count: 4 #4
+    flavor: c1.c28m935d50
+    group: compute
+    docker_ready: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: soft
+      mem_reserved_size: 2048
+  worker-c28m875:
+    count: 2 #2
+    flavor: c1.c28m875d50
     group: compute
     docker_ready: true
     volume:
@@ -196,9 +221,22 @@ deployment:
     cgroups:
       mem_limit_policy: hard
       mem_reserved_size: 2048
-  worker-gpu:
-    count: 8 #16
-    flavor: g1.c7m20g1d50
+  worker-c14m40g1:
+    count: 4 #4
+    flavor: g1.c14m40g1d50
+    group: compute_gpu
+    gpu_ready: true
+    docker_ready: true
+    volume:
+      size: 1024
+      type: default
+      boot: true
+    cgroups:
+      mem_limit_policy: soft
+      mem_reserved_size: 1024
+  worker-c8m40g1:
+    count: 4 #4
+    flavor: g1.c8m40g1d50
     group: compute_gpu
     gpu_ready: true
     docker_ready: true

--- a/schema.yaml
+++ b/schema.yaml
@@ -80,8 +80,10 @@ mapping:
                             - c1.c120m225d50
                             - c1.c120m425d50
                             - c1.c125m425d50
-                            - g1.c36m100g1d50
-                            - g1.c7m20g1d50
+                            - c1.c28m935d50
+                            - c1.c28m875d50
+                            - g1.c14m40g1d50
+                            - g1.c8m40g1d50
                             - m1.large
                             - m1.medium
                             - m1.nano


### PR DESCRIPTION
July 13, 2023, was the GPU infra maintenance. On this day we did the following restructuring

```
1. 4 GPUs from T4 will be moved out so the rest of the ones will have double the resources
	1. A new flavor will be created: g1.c14m40g1
2. 4 GPUs removed from T4 will be moved to n36[59-62]:
	1. New flavors:
		1. g1.c8m40g1 (4 VMs); c1.c28m935 (4 VMs)
3. 2 GPUs from n36[11, 12] to n36[63, 64] will be relocated as well
	1. New flavors:
		1. g1.c8m100g1 (2 VMs); c1.c28m875 (2 VMs)
4. n36[11, 12] will be repurposed as CPU hosts and adjust the reservation
```

As a result of this change, the following adjustments were made,

```
g1.c14m40g1d50 => 4 VMs
g1.c8m40g1d50 => 4 VMs
g1.c8m100g1d50 => 2 (User's GPU VMs: Anup for now, his gpu-alpha VM)
c1.c28m935d50 => 4 VMs
c1.c28m875d50 => 2 VMs
c1.c36m975d50 => 8 VMs (reduced from 14)
c1.c36m100d50 => Increased from 30 to 32 VMs (repurposed the g1.c36m100g1d50 flavor as CPU flavor so +2)
g1.c36m100g1d50 => No more and it is now re-flavored as g1.c8m100g1d50 (Adjustment should be made in the infrastructure repo)
```

I will update the respective documentation in the operations repo.
