### PR TITLE
Use GPU image with preinstalled NVIDIA drivers

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -4,8 +4,8 @@
 image: vggp-v60-j322-692e75a7c101-main
 image_id: 4c864d3b-6651-4bb3-a329-4a7c8c18a8fa
 
-image_gpu: vggp-v60-gpu-j322-692e75a7c101-main
-image_gpu_id: f5b82cb0-03b4-44f0-8ce5-33f15c53f89b
+image_gpu: vggp-v60-gpu-j322-692e75a7c101-main-kernel-4.18.0-477.21.1.el8_8-nvidia
+image_gpu_id: 99457af8-bb9f-4a8a-94a9-5dd5a878e95c
 
 image_secure: vggp-v60-secure-j322-692e75a7c101-main
 image_secure_id: 02b59caf-374d-4cef-aafc-d86fe0aeb9ce


### PR DESCRIPTION
This PR changes the GPU image to `vggp-v60-gpu-j322-692e75a7c101-main-kernel-4.18.0-477.21.1.el8_8-nvidia`, which has been generated by mounting `vggp-v60-gpu-j322-692e75a7c101-main` and installing `cuda-10-1` and `nvidia-container-toolkit`.

This is precisely what cloud-init was doing up to now, but as the driver install requires a kernel update, having the drivers preinstalled means that the first boot already runs the proper kernel version.

This solution is far from ideal, but for various reasons it was difficult to recreate the image from scratch only with the desired changes (I wanted to avoid breaking things as well). In the future we should give more love to the image building process.