### PR TITLE
Remove GPU-related packages from the cloud-init user data file

### DIFF
--- a/userdata.yaml.j2
+++ b/userdata.yaml.j2
@@ -1,9 +1,4 @@
 #cloud-config
-{% if image is defined and image == "gpu" %}
-packages:
-  - cuda-10-1
-  - nvidia-container-toolkit
-{% endif %}
 write_files:
   - content: |
       # BEGIN MANAGED BLOCK


### PR DESCRIPTION
They are not needed anymore because the GPU image includes them.