### PR TITLE
Define the `required` key for most keys from schema.yaml and default the key `docker` to False

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -4,6 +4,7 @@ mapping:
     # Global configuration of computing nodes.
     "images":
         type: map
+        required: true
         mapping:
             "default":
                 type: str
@@ -38,6 +39,7 @@ mapping:
     # Resource group definitions.
     "deployment":
         type: map
+        required: true
         mapping:
             "=":
                 type: map
@@ -74,17 +76,21 @@ mapping:
                             - m1.xxlarge
                     "start":
                         type: date
+                        required: false
                         format: "%Y-%m-%d"
                     "end":
                         type: date
+                        required: false
                         format: "%Y-%m-%d"
                     "group":
                         type: str
+                        required: true
                     "image":
                         type: str
                         required: false
                     "volume":
                         type: map
+                        required: false
                         'mapping':
                             "size":
                                 type: int
@@ -99,6 +105,7 @@ mapping:
                                 type: bool
                     "cgroups":
                         type: map
+                        required: false
                         'mapping':
                             "mem_limit_policy":
                                 type: str
@@ -112,3 +119,4 @@ mapping:
                                     min: 1024
                     "docker":
                         type: bool
+                        required: false

--- a/synchronize.py
+++ b/synchronize.py
@@ -592,14 +592,6 @@ def template_userdata(
             rendering the template.
     """
     vars_files = frozenset(vars_files)
-    vars_from_files = (
-        reduce(
-            lambda x, y: x.update(y),
-            (yaml.safe_load(open(file, "r")) for file in vars_files),
-        )
-        if vars_files
-        else {}
-    )
 
     environment = Environment(
         loader=FileSystemLoader(user_data_file.parent),
@@ -609,11 +601,25 @@ def template_userdata(
         user_data_file.name,
     )
 
+    group_defaults = {
+        "docker": False,
+    }
+    vars_from_files = (
+        reduce(
+            lambda x, y: x.update(y),
+            (yaml.safe_load(open(file, "r")) for file in vars_files),
+        )
+        if vars_files
+        else {}
+    )
+
+    variables = {}
+    for vars_group in (group_defaults, config, group_config, vars_from_files):
+        variables.update(vars_group)
+
     return template.render(
         name=name,
-        **config,
-        **group_config,
-        **vars_from_files,
+        **variables,
     )
 
 

--- a/tests.py
+++ b/tests.py
@@ -1440,6 +1440,7 @@ def test_template_userdata() -> None:
             owner: root:root
             path: /etc/configuration_file
             permissions: "0644"
+            docker: {{ docker }}
     """
     )[1:]
 
@@ -1481,6 +1482,7 @@ def test_template_userdata() -> None:
             owner: root:root
             path: /etc/configuration_file
             permissions: "0644"
+            docker: False
     """
     )[1:-1]
     assert templated == expected


### PR DESCRIPTION
Even though `required: false` is the default when it comes to validating the schema, I think it's good to make things explicit.

Moreover, the code in synchronize.py has been changed to use `docker: false` as default when the key is undefined.

@bgruening having `docker: false` when undefined was the default for ensure_enough.py, but I think it's good to ask if that's what you intended in #221.