### PR TITLE
Fix GalaxyGroup not being advertised

### DIFF
--- a/userdata.yaml.j2
+++ b/userdata.yaml.j2
@@ -33,8 +33,8 @@ write_files:
       GPU_DISCOVERY_EXTRA = -extra
       {% endif %}
       GalaxyTraining = {{ "training" in name }}
-      GalaxyGroup = {{ group }}
-      GalaxyCluster = denbi
+      GalaxyGroup = "{{ group }}"
+      GalaxyCluster = "denbi"
       GalaxyDockerHack = {{ docker }}
       STARTD_ATTRS = GalaxyTraining, GalaxyGroup, GalaxyCluster, GalaxyDockerHack
       Rank = StringListMember(MY.GalaxyGroup, TARGET.Group)


### PR DESCRIPTION
It is also likely that the same issue also applies to GalaxyCluster, so I also changed it.

I just realized this looking at working `condor_config.local` files. 