### PR TITLE
Fix bug merging vars files in synchronize.py

### DIFF
--- a/synchronize.py
+++ b/synchronize.py
@@ -608,7 +608,7 @@ def template_userdata(
     }
     vars_from_files = (
         reduce(
-            lambda x, y: x.update(y),
+            lambda x, y: x | y,
             (yaml.safe_load(open(file, "r")) for file in vars_files),
         )
         if vars_files


### PR DESCRIPTION
Fix bug in `template_userdata` function.

Variables from vars files are merged in a single dictionary (`variables`) before userdata.yaml.j2 is rendered. This is done using the `reduce` function from `functools`.

However, the function passed to `reduce` as first argument (`lambda x, y: x.update(y)`) returns `None` instead of a dictionary. Replacing it with `x | y` solves the problem.