### PR TITLE
Move vgcn-mounts.yml.j2 template from mounts repository to userdata.yaml.j2

### DIFF
--- a/userdata.yaml.j2
+++ b/userdata.yaml.j2
@@ -67,3 +67,21 @@ write_files:
     owner: root:root
     path: /etc/auto.master.d/data.autofs
     permissions: "0644"
+  - content: |
+      {% for mount in dnb.values() -%}
+        {{ mount.name }}	-{{ mount.nfs_options | join(',') }}	{{ mount.export }}
+      {% endfor -%}
+      {% for mount in jwd.values() -%}
+        {{ mount.name }}	-{{ mount.nfs_options | join(',') }}	{{ mount.export }}
+      {% endfor %}
+    owner: root:root
+    path: /etc/auto.data
+    permissions: "0644"
+  - content: |
+      {% for mount in tools.values() -%}
+        {{ mount.path }}      -{{ mount.nfs_options | join(',') }}		{{ mount.export }}
+      {% endfor -%}
+        {{ sync.gxkey.path }}	-{{ sync.gxkey.nfs_options | join(',') }}	{{ sync.gxkey.export }}
+    owner: root:root
+    path: /etc/auto.usrlocal
+    permissions: "0644"


### PR DESCRIPTION
Move the contents of vgcn-mounts.yml.j2 from the mounts repository to userdata.yaml.j2.

Removes the need to call `cd mounts; rm -f dest/*; make dest/vgcn-mounts.yml; cd  ..` in Jenkins, makes it possible to remove vgcn-mounts.yml and templates/vgcn-mounts.yml.j2 from the mounts repository.

Again, we did not do this in the past because [userdata.yaml.j2](https://github.com/usegalaxy-eu/vgcn-infrastructure/blob/main/userdata.yaml.j2) was not a Jinja template.

This is the rendered template:

```
[...]
  - content: |
      db        -hard,rw,nosuid,nconnect=2      ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
      dp01      -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dataplant01
      0 -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/depot/&
      1 -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/depot/&
      2 -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/depot/&
      3 -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/depot/&
      4 -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/depot/&
      5 -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/depot/&
      6 -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/depot/&
      7 -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/dnb01/depot/&
      dnb-ds01  -hard,rw,nosuid,nconnect=2,nodev        denbi.svm.bwsfs.uni-freiburg.de:/dnb01-legacy
      dnb-ds02  -hard,rw,nosuid,nconnect=2,nodev        denbi.svm.bwsfs.uni-freiburg.de:/dnb02-legacy
      dnb-ds03  -hard,rw,nosuid,nconnect=2,nodev        denbi.svm.bwsfs.uni-freiburg.de:/dnb03-legacy
      dnb01     -hard,rw,nosuid,nconnect=2,nodev        ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
      dnb02     -hard,rw,nosuid,nconnect=2,nodev        ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
      dnb04     -hard,rw,nosuid,nconnect=2,nodev        ufr-dyn.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
      dnb05     -hard,rw,nosuid,nconnect=2,nodev        denbi.svm.bwsfs.uni-freiburg.de:/dnb01/&
      dnb06     -hard,rw,nosuid,nconnect=2,nodev        denbi.svm.bwsfs.uni-freiburg.de:/dnb06
      dnb07     -hard,rw,nosuid,nconnect=2,nodev        denbi.svm.bwsfs.uni-freiburg.de:/dnb07
      dnb08     -hard,rw,nosuid,nconnect=2,nodev        denbi.svm.bwsfs.uni-freiburg.de:/dnb08
      dnb09     -hard,rw,nosuid,nconnect=2,nodev        denbi.svm.bwsfs.uni-freiburg.de:/dnb09
      jwd       -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/ws01/&
      jwd01     -hard,rw,nosuid zfs1.galaxyproject.eu:/export/&
      jwd02f    -hard,rw,nosuid zfs2f.galaxyproject.eu:/export/&
      jwd03f    -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/ws02/&
      jwd04     -hard,rw,nosuid zfs3f.galaxyproject.eu:/export/&
      jwd05e    -hard,rw,nosuid zfs3f.galaxyproject.eu:/export/&
      birna01   -hard,rw,nosuid,nodev,nconnect=2        denbi.svm.bwsfs.uni-freiburg.de:/&
      
    owner: root:root
    path: /etc/auto.data
    permissions: "0644"
  - content: |
      /usr/local/tools      -hard,rw,nosuid,nconnect=2          denbi.svm.bwsfs.uni-freiburg.de:/dnb01/tools
      /opt/galaxy       -hard,rw,nosuid,nconnect=2      denbi.svm.bwsfs.uni-freiburg.de:/ws01/galaxy-sync/main
    owner: root:root
    path: /etc/auto.usrlocal
    permissions: "0644"

```
