### PR TITLE
Enable vgcn-infrastructure repo to spawn nodes belonging to the secondary HTCondor cluster

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -5,6 +5,7 @@ images:
   gpu: vggp-v60-gpu-j322-692e75a7c101-main-kernel-4.18.0-477.21.1.el8_8-nvidia
   secure: vggp-v60-secure-j322-692e75a7c101-main
   alma: vggp-v60-j342-4c09f3ebbeac-alma
+  htcondor-secondary: vgcn~workers+internal~rockylinux-8.6-x86_64~2023-10-26-43739-htcondor-secondary~ebb20b8~kysrpex_local_build
 network: bioinf
 secgroups:
   - ufr-ingress

--- a/resources.yaml
+++ b/resources.yaml
@@ -36,6 +36,20 @@ nodes_inventory:
   g1.c8m40g1d50: 4
 
 deployment:
+  # worker-c120m225-htcondor-secondary:
+  #   count: 1 #12
+  #   flavor: c1.c120m225d50
+  #   group: compute
+  #   docker: true
+  #   image: htcondor-secondary
+  #   secondary_htcondor_cluster: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: hard
+  #     mem_reserved_size: 2048
+
   worker-maintenance:
     count: 1
     flavor: m1.large

--- a/userdata.yaml.j2
+++ b/userdata.yaml.j2
@@ -1,5 +1,6 @@
 #cloud-config
 write_files:
+  {% if not (secondary_htcondor_cluster | default(false)) -%}
   - content: |
       # BEGIN MANAGED BLOCK
       ETC = /etc/condor
@@ -52,6 +53,34 @@ write_files:
     owner: root:root
     path: /etc/condor/condor_config.local
     permissions: "0644"
+  {% else -%}
+  - content: |
+      {% if image is defined and image == "gpu" -%}
+      # Advertise the GPUs
+      use feature : GPUs
+      GPU_DISCOVERY_EXTRA = -extra
+      {% endif -%}
+      GalaxyTraining = {{ "training" in name }}
+      GalaxyGroup = "{{ group }}"
+      GalaxyCluster = "denbi"
+      GalaxyDockerHack = {{ docker }}
+      STARTD_ATTRS = GalaxyTraining, GalaxyGroup, GalaxyCluster, GalaxyDockerHack
+      Rank = StringListMember(MY.GalaxyGroup, TARGET.Group)
+      {% if cgroups is defined -%}
+      BASE_CGROUP = /system.slice/condor.service
+      {% if cgroups.mem_limit_policy is defined -%}
+      CGROUP_MEMORY_LIMIT_POLICY = {{ cgroups.mem_limit_policy }}
+      {% endif -%}
+      {% if cgroups.mem_reserved_size is defined -%}
+      RESERVED_MEMORY = {{ cgroups.mem_reserved_size }}
+      {% else -%}
+      RESERVED_MEMORY = 1024
+      {% endif -%}
+      {% endif %}
+    owner: root:root
+    path: /etc/condor/config.d/99-cloud-init.conf
+    permissions: "0644"
+  {% endif -%}
   - content: |
       [[outputs.influxdb]]
         urls = ["https://influxdb.galaxyproject.eu:8086"]


### PR DESCRIPTION
Use the existing /etc/condor/condor_config.local template from userdata.yaml.j2 only for worker nodes belonging to the primary cluster (groups defined in resources.yaml with `secondary_htcondor_cluster: false` or undefined).

Add a second template, /etc/condor/config.d/99-cloud-init.conf, used only for worker nodes belonging to the secondary cluster (groups defined in resources.yaml with `secondary_htcondor_cluster: true`). Note that placing the file in /etc/condor/config.d instead of overwriting /etc/condor_condor_config.local allows to configure HTCondor both within the image and via cloud-init. The latter makes sense, for example, to configure the STARTD attributes that differ for each group (such as "GalaxyGroup", "GalaxyDockerHack", etc).

Add the secondary HTCondor cluster image to resources.yaml.

Add an example on how to spawn a worker that will join the secondary HTCondor cluster. The example is just meant to show how it works. It may make sense to consider an alternative solution that avoids duplicating everything and facilitates the management of the share of machines belonging to each cluster.