### PR TITLE
Move four machines to the secondary HTCondor cluster to test it

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -36,19 +36,48 @@ nodes_inventory:
   g1.c8m40g1d50: 4
 
 deployment:
-  # worker-c120m225-htcondor-secondary:
-  #   count: 1 #12
-  #   flavor: c1.c120m225d50
-  #   group: compute
-  #   docker: true
-  #   image: htcondor-secondary
-  #   secondary_htcondor_cluster: true
-  #   volume:
-  #     size: 1024
-  #     type: default
-  #   cgroups:
-  #     mem_limit_policy: hard
-  #     mem_reserved_size: 2048
+  worker-fetch-htcondor-secondary:
+    count: 1
+    flavor: c1.c36m100d50
+    image: htcondor-secondary
+    secondary_htcondor_cluster: true
+    group: upload
+  worker-interactive-htcondor-secondary:
+    count: 1
+    flavor: c1.c36m100d50
+    group: interactive
+    docker: true
+    image: htcondor-secondary
+    secondary_htcondor_cluster: true
+    volume:
+      size: 1024
+      type: default
+  worker-c36m100-htcondor-secondary:
+    count: 1
+    flavor: c1.c36m100d50
+    group: compute
+    image: htcondor-secondary
+    secondary_htcondor_cluster: true
+    docker: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: hard
+      mem_reserved_size: 2048
+  worker-c8m40g1-htcondor-secondary:
+    count: 1
+    flavor: g1.c8m40g1d50
+    group: compute_gpu
+    image: htcondor-secondary-gpu
+    secondary_htcondor_cluster: true
+    docker: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: soft
+      mem_reserved_size: 1024
 
   worker-fastturnaround:
     count: 1


### PR DESCRIPTION
Move three `c1.c36m100d50` and one `g1.c8m40g1d50` machine to the secondary HTCondor cluster to test it.

That makes all regular groups available in the secondary cluster (`upload`, `interactive`, `compute` and `compute_gpu`). Training groups are exempt from this test.

Python will process the entries in the same order they appear in resources.yaml. Thus, given than during the first run of synchronize.py sufficient hosts are available, the persistence of the four machines is guaranteed. The entries for the primary cluster need not be modified (just fewer hosts will be available and OpenStack will complain as usual `ERROR:root:OpenStack error 500: No valid host was found. There are not enough hosts available.`).

This solution is meant to be used to test the cluster with just those four machines. I think for the actual migration something smarter is preferred.

Requires #239.