### PR TITLE
Fix `htcondor-secondary` image name

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -5,7 +5,7 @@ images:
   gpu: vggp-v60-gpu-j322-692e75a7c101-main-kernel-4.18.0-477.21.1.el8_8-nvidia
   secure: vggp-v60-secure-j322-692e75a7c101-main
   alma: vggp-v60-j342-4c09f3ebbeac-alma
-  htcondor-secondary: vgcn~workers+internal~rockylinux-8.6-x86_64~2023-10-26-43739-htcondor-secondary~ebb20b8~kysrpex_local_build
+  htcondor-secondary: vgcn~workers+internal~rockylinux-8.6-x86_64~2023-10-26~43739~htcondor-secondary~ebb20b8~kysrpex_local_build
 network: bioinf
 secgroups:
   - ufr-ingress


### PR DESCRIPTION
Rename `htcondor-secondary` image to follow naming conventions from https://github.com/usegalaxy-eu/vgcn/issues/78.