### PR TITLE
Extend schema.yaml with the `secondary_htcondor_cluster` boolean

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -120,3 +120,6 @@ mapping:
                     "docker":
                         type: bool
                         required: false
+                    "secondary_htcondor_cluster":
+                        type: bool
+                        required: false


### PR DESCRIPTION
The boolean `secondary_htcondor_cluster` declares a group to be a member of the secondary HTCondor cluster. Allow it in schema.yaml.