### PR TITLE
Enable advertising GPUs for worker nodes booting from an image whose label ends with "gpu" (only affects the secondary HTcondor cluster)

### DIFF
--- a/userdata.yaml.j2
+++ b/userdata.yaml.j2
@@ -55,7 +55,7 @@ write_files:
     permissions: "0644"
   {% else -%}
   - content: |
-      {% if image is defined and image == "gpu" -%}
+      {% if image is defined and image.endswith("gpu") -%}
       # Advertise the GPUs
       use feature : GPUs
       GPU_DISCOVERY_EXTRA = -extra


### PR DESCRIPTION
Advertise GPUs for images whose label ends with "gpu" rather than for images whose label equals "gpu". Only affects the secondary HTcondor cluster.

