### PR TITLE
Revert "Move four machines to the secondary HTCondor cluster to test it"

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -37,48 +37,19 @@ nodes_inventory:
   g1.c8m40g1d50: 4
 
 deployment:
-  worker-fetch-htcondor-secondary:
-    count: 1
-    flavor: c1.c36m100d50
-    image: htcondor-secondary
-    secondary_htcondor_cluster: true
-    group: upload
-  worker-interactive-htcondor-secondary:
-    count: 1
-    flavor: c1.c36m100d50
-    group: interactive
-    docker: true
-    image: htcondor-secondary
-    secondary_htcondor_cluster: true
-    volume:
-      size: 1024
-      type: default
-  worker-c36m100-htcondor-secondary:
-    count: 1
-    flavor: c1.c36m100d50
-    group: compute
-    image: htcondor-secondary
-    secondary_htcondor_cluster: true
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: hard
-      mem_reserved_size: 2048
-  worker-c8m40g1-htcondor-secondary:
-    count: 1
-    flavor: g1.c8m40g1d50
-    group: compute_gpu
-    image: htcondor-secondary-gpu
-    secondary_htcondor_cluster: true
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: soft
-      mem_reserved_size: 1024
+  # worker-c120m225-htcondor-secondary:
+  #   count: 1 #12
+  #   flavor: c1.c120m225d50
+  #   group: compute
+  #   docker: true
+  #   image: htcondor-secondary
+  #   secondary_htcondor_cluster: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: hard
+  #     mem_reserved_size: 2048
 
   worker-fetch:
     count: 1


### PR DESCRIPTION
Reverts usegalaxy-eu/vgcn-infrastructure#240

The fraction of resources allocated to the secondary HTCondor cluster will be managed via Jenkins now.

⚠️ Do not merge this yourself! It requires careful synchronization with #244.