### PR TITLE
Remove AlmaLinux workers

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -4,7 +4,6 @@ images:
   default: vggp-v60-j322-692e75a7c101-main
   gpu: vggp-v60-gpu-j322-692e75a7c101-main-kernel-4.18.0-477.21.1.el8_8-nvidia
   secure: vggp-v60-secure-j322-692e75a7c101-main
-  alma: vggp-v60-j342-4c09f3ebbeac-alma
   htcondor-secondary: vgcn~workers+internal~rockylinux-8.6-x86_64~2023-10-26~43739~htcondor-secondary~ebb20b8~kysrpex_local_build
   htcondor-secondary-gpu: vgcn~workers-gpu+internal~rockylinux-8.6-x86_64~2023-11-16~34096~htcondor-secondary~a23fbb0~kysrpex_local_build
 network: bioinf
@@ -200,20 +199,8 @@ deployment:
     cgroups:
       mem_limit_policy: hard
       mem_reserved_size: 2048
-  worker-c120m425-alma:
-    count: 2 #22
-    flavor: c1.c120m425d50
-    group: compute
-    docker: true
-    image: alma
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: hard
-      mem_reserved_size: 2048
   worker-c120m425:
-    count: 20 #22
+    count: 22
     flavor: c1.c120m425d50
     group: compute
     docker: true


### PR DESCRIPTION
We have tested them for a while and know that changing the OS does not solve the problem with VMs becoming stuck, so let's remove the AlmaLinux workers.