### PR TITLE
Fix cgroups in the secondary cluster

### DIFF
--- a/userdata.yaml.j2
+++ b/userdata.yaml.j2
@@ -67,7 +67,7 @@ write_files:
       STARTD_ATTRS = GalaxyTraining, GalaxyGroup, GalaxyCluster, GalaxyDockerHack
       Rank = StringListMember(MY.GalaxyGroup, TARGET.Group)
       {% if cgroups is defined -%}
-      BASE_CGROUP = /system.slice/condor.service
+      BASE_CGROUP = system.slice/condor.service
       {% if cgroups.mem_limit_policy is defined -%}
       CGROUP_MEMORY_LIMIT_POLICY = {{ cgroups.mem_limit_policy }}
       {% endif -%}


### PR DESCRIPTION
In /etc/condor/config.d/99-cloud-init.conf `BASE_CGROUP` is set to `/system.slice/condor.service`. This worked with HTCondor 8 but HTCondor 23 does not request the cgroup if it starts with "/". Set `BASE_CGROUP` to `system.slice/condor.service`.

Closes [usegalaxy-eu/issues#505](https://github.com/usegalaxy-eu/issues/issues/505) (see that issue for a more detailed explanation of the source of the problem).