### PR TITLE
Reverts the portion of the PR from #224

### DIFF
--- a/synchronize.py
+++ b/synchronize.py
@@ -44,10 +44,6 @@ from paramiko.client import AutoAddPolicy
 from paramiko.file import BufferedFile
 from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 
-from htcondor_migration import (
-    allocate_resources as htcondor_migration_resource_allocation,
-)
-
 # server names are constructed as
 #   vgcnbwc-{group_identifier}-{unique_id}
 PREFIX: str = "vgcnbwc-"
@@ -1039,16 +1035,6 @@ def make_parser() -> argparse.ArgumentParser:
         type=str,
         help="OpenStack cloud name in clouds.yaml",
     )
-    # HTCondor 23 migration
-    parser.add_argument(
-        "-f",
-        "--fraction",
-        dest="resource_fraction",
-        type=float,
-        metavar="resource_fraction",
-        help="fraction of resources to be allocated to the secondary cluster",
-        default=0.0,
-    )
     parser.add_argument(
         "-d",
         "--dry-run",
@@ -1070,19 +1056,8 @@ if __name__ == "__main__":
         load_envvars=False,
     )
 
-    # HTCondor 23 migration
-    resources = yaml.safe_load(open(command_args.resources_file))
-    resources = htcondor_migration_resource_allocation(
-        resources,
-        fraction=command_args.resource_fraction,
-    )
-    logging.info(
-        f"Modified `resources.yaml` for the HTCondor 23 migration:\n"
-        f"{yaml.dump(resources, sort_keys=False)}"
-    )
-
     synchronize_infrastructure(
-        config=resources,
+        config=yaml.safe_load(open(command_args.resources_file)),
         user_data=command_args.userdata_file,
         cloud=openstack_cloud,
         dry_run=command_args.dry_run,


### PR DESCRIPTION
This PR will revert the internal modification of the migration to the secondary cluster via the sync script that was added via the PR [#224](https://github.com/usegalaxy-eu/vgcn-infrastructure/pull/244).

With this cleanup the names of the newly launched VMs will not have double `htcondor-secondary` added to the end of their names (example, now the newly launched VMs has `vgcnbwc-worker-c125m425-htcondor-secondary-htcondor-secondary-0002`; build job: https://build.galaxyproject.eu/job/usegalaxy-eu/job/vgcn-infrastructure/44621/console). 

**Note: When this PR is merged the argument `-f 1` should be immediately removed from the `vgcn-infrastructure` build script**