### PR TITLE
Update training resources and integrate them to the secondary cluster

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -67,7 +67,7 @@ deployment:
       size: 1024
       type: default
   worker-c28m475-htcondor-secondary:
-    count: 10 #19
+    count: 8 #19
     flavor: c1.c28m475d50
     group: compute
     docker: true
@@ -254,6 +254,14 @@ deployment:
     group: training-ga-embo24
     image: htcondor-secondary
     secondary_htcondor_cluster: true
+  training-ga-e2:
+    count: 1
+    flavor: c1.c28m475d50
+    start: 2024-01-28
+    end: 2024-02-03
+    group: training-ga-embo24
+    image: htcondor-secondary
+    secondary_htcondor_cluster: true
   training-asse:
     count: 3
     flavor: c1.c28m225d50
@@ -281,6 +289,14 @@ deployment:
   training-embo-fs2:
     count: 6
     flavor: c1.c36m225d50
+    start: 2024-01-28
+    end: 2024-02-03
+    group: training-embo-genomeass24
+    image: htcondor-secondary
+    secondary_htcondor_cluster: true
+  training-embo-fs3:
+    count: 1
+    flavor: c1.c28m475d50
     start: 2024-01-28
     end: 2024-02-03
     group: training-embo-genomeass24


### PR DESCRIPTION
1. This PR will enable spawning and integrating all currently listed training in the `resources.yaml` in the secondary c.luster.
2. Since we do not have more than 7 VMs in the flavor `c1.c28m225d50`, which is used for the training, I have split the training `training-embo` to `training-embo-fs1` and `training-embo-fs2` (`fs` = flavor split). For `fs1`, we will use `c1.c28m225d50`; for `fs2`, we will borrow the compute workers of flavor `c1.c36m225d50`. **So before merging this, please do not forget to drain 6 nodes of the flavor `c1.c36m225d50` from the secondary cluster and delete them from the cloud**

**_Draft reason: The number of VMs of the flavor `c36m225d50` that can be spawned (15) and already spawned (total 11; 1 in the old cluster and 10 in the new cluster; none spawned via the infrastructure repo) does not match. I have pinged Manuel requesting the details; I will update the PR accordingly once I get the clarification._**