### PR TITLE
remove training ga-embo24 resources and redistribute it to htgeno and embo-genomeass24 training

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -246,20 +246,12 @@ deployment:
     image: htcondor-secondary-gpu
     secondary_htcondor_cluster: true
 
-  training-ga-e:
+  training-htgeno:
     count: 3
     flavor: c1.c28m225d50
-    start: 2024-01-28
+    start: 2024-01-29
     end: 2024-02-03
-    group: training-ga-embo24
-    image: htcondor-secondary
-    secondary_htcondor_cluster: true
-  training-ga-e2:
-    count: 1
-    flavor: c1.c28m475d50
-    start: 2024-01-28
-    end: 2024-02-03
-    group: training-ga-embo24
+    group: training-htgeno
     image: htcondor-secondary
     secondary_htcondor_cluster: true
   training-asse:
@@ -295,7 +287,7 @@ deployment:
     image: htcondor-secondary
     secondary_htcondor_cluster: true
   training-embo-fs3:
-    count: 1
+    count: 2
     flavor: c1.c28m475d50
     start: 2024-01-28
     end: 2024-02-03


### PR DESCRIPTION
The underlying resources had been drained (condor) and deleted from the cloud.

Reason:
`ga-embo24` and `embo-genomeass24` are redundant and requested by the same person in different periods, hence the removal and redistribution.