### PR TITLE
No fetch wokers for now

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -51,7 +51,7 @@ deployment:
   #     mem_reserved_size: 2048
 
   worker-fetch-htcondor-secondary:
-    count: 1
+    count: 0
     flavor: c1.c36m100d50
     group: upload
     image: htcondor-secondary


### PR DESCRIPTION
Since the fetch workers are not used currently, this will be removed to save compute resources.
fixes:
- https://github.com/usegalaxy-eu/issues/issues/512
temporarily