### PR TITLE
Merge on 2024-03-05

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -247,14 +247,7 @@ deployment:
     secondary_htcondor_cluster: true
 
   # Trainings
-  training-asse:
-    count: 3
-    flavor: c1.c28m225d50
-    start: 2024-03-18
-    end: 2024-03-22
-    group: training-assemblyannotation
-    image: htcondor-secondary
-    secondary_htcondor_cluster: true
+  # These will overlap on Mar 6
   training-kmb6:
     count: 1
     flavor: c1.c28m225d50
@@ -264,11 +257,44 @@ deployment:
     image: htcondor-secondary
     secondary_htcondor_cluster: true
   training-hts-:
-    count: 3
+    count: 2
     flavor: c1.c28m225d50
     start: 2024-03-04
     end: 2024-03-08
     group: training-hts-fr
+    image: htcondor-secondary
+    secondary_htcondor_cluster: true
+  training-path-gen-march-24:
+    count: 2
+    flavor: c1.c28m225d50
+    start: 2024-03-04
+    end: 2024-03-15
+    group: training-path-gen-march-24
+    image: htcondor-secondary
+    secondary_htcondor_cluster: true
+  training-msc-exe:
+    count: 1
+    flavor: c1.c28m225d50
+    start: 2024-03-06
+    end: 2024-03-06
+    group: training-msc-exe
+    image: htcondor-secondary
+    secondary_htcondor_cluster: true
+  training-msc-exeter:
+    count: 1
+    flavor: c1.c28m225d50
+    start: 2024-03-07
+    end: 2024-03-20
+    group: training-msc-exeter
+    image: htcondor-secondary
+    secondary_htcondor_cluster: true
+
+  training-asse:
+    count: 1
+    flavor: c1.c28m225d50
+    start: 2024-03-18
+    end: 2024-03-22
+    group: training-assemblyannotation
     image: htcondor-secondary
     secondary_htcondor_cluster: true
   training-gie-:
@@ -277,22 +303,6 @@ deployment:
     start: 2024-03-18
     end: 2024-03-19
     group: training-gie-0324
-    image: htcondor-secondary
-    secondary_htcondor_cluster: true
-  training-msc-exe:
-    count: 2
-    flavor: c1.c28m225d50
-    start: 2024-03-06
-    end: 2024-03-06
-    group: training-msc-exe
-    image: htcondor-secondary
-    secondary_htcondor_cluster: true
-  training-msc-exeter:
-    count: 2
-    flavor: c1.c28m225d50
-    start: 2024-03-07
-    end: 2024-03-20
-    group: training-msc-exeter
     image: htcondor-secondary
     secondary_htcondor_cluster: true
   training-cais:
@@ -325,13 +335,5 @@ deployment:
     start: 2024-02-27
     end: 2024-03-01
     group: training-ufz-trans-2024
-    image: htcondor-secondary
-    secondary_htcondor_cluster: true
-  training-path-gen-march-24:
-    count: 2
-    flavor: c1.c28m225d50
-    start: 2024-03-04
-    end: 2024-03-15
-    group: training-path-gen-march-24
     image: htcondor-secondary
     secondary_htcondor_cluster: true

--- a/resources.yaml
+++ b/resources.yaml
@@ -283,7 +283,7 @@ deployment:
   training-msc-exeter:
     count: 1
     flavor: c1.c28m225d50
-    start: 2024-03-07
+    start: 2024-03-06
     end: 2024-03-20
     group: training-msc-exeter
     image: htcondor-secondary


### PR DESCRIPTION
I think the best approach is to open multiple PRs named like dates when we want to change the tiaas distribution.
this PR prepares for March 6 when we have 5 trainings in parallel