### PR TITLE
no kernel-lt image

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -6,7 +6,7 @@ images:
   secure: vggp-v60-secure-j322-692e75a7c101-main
   htcondor-secondary: vgcn~workers+internal~rockylinux-8.6-x86_64~2023-10-26~43739~htcondor-secondary~ebb20b8~kysrpex_local_build
   htcondor-secondary-gpu: vgcn~workers-gpu+internal~rockylinux-8.6-x86_64~2023-11-16~34096~htcondor-secondary~a23fbb0~kysrpex_local_build
-  rocky-9: vgcn~rockylinux-9-latest-x86_64~+generic+workers+internal~20240307~38383~dev~5809053~non_gpu_locally_built_by_mira
+  rocky-9: vgcn~rockylinux-9-latest-x86_64~+generic+workers+internal~20240314~40429~dev~9f80854~2nd_test_no_kernel_lt_by_mira
 network: bioinf
 secgroups:
   - ufr-ingress


### PR DESCRIPTION
Let's try without and if it works I would suggest building images from OS major version >8 without kernel-lt package