### PR TITLE
Cloud redeployment in phase by phase

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -48,164 +48,164 @@ deployment:
   #     mem_limit_policy: hard
   #     mem_reserved_size: 2048
 
-  worker-fetch:
-    count: 0
-    flavor: c1.c36m100d50
-    group: upload
-    image: default
+  # worker-fetch:
+  #   count: 0
+  #   flavor: c1.c36m100d50
+  #   group: upload
+  #   image: default
 
-  worker-interactive:
-    count: 4 #8
-    flavor: c1.c36m100d50
-    group: interactive
-    docker: true
-    image: default
+  # worker-interactive:
+  #   count: 4 #8
+  #   flavor: c1.c36m100d50
+  #   group: interactive
+  #   docker: true
+  #   image: default
 
-    volume:
-      size: 1024
-      type: default
-  worker-c28m475:
-    count: 10 #19
-    flavor: c1.c28m475d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: hard
-      mem_reserved_size: 2048
-    image: default
+  #   volume:
+  #     size: 1024
+  #     type: default
+  # worker-c28m475:
+  #   count: 10 #19
+  #   flavor: c1.c28m475d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: hard
+  #     mem_reserved_size: 2048
+  #   image: default
 
-  worker-c28m225:
-    count: 0
-    flavor: c1.c28m225d50
-    group: compute_test
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: hard
-      mem_reserved_size: 2048
-    image: default
+  # worker-c28m225:
+  #   count: 0
+  #   flavor: c1.c28m225d50
+  #   group: compute_test
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: hard
+  #     mem_reserved_size: 2048
+  #   image: default
 
-  worker-c36m100:
-    count: 26 #32
-    flavor: c1.c36m100d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: hard
-      mem_reserved_size: 2048
-    image: default
+  # worker-c36m100:
+  #   count: 26 #32
+  #   flavor: c1.c36m100d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: hard
+  #     mem_reserved_size: 2048
+  #   image: default
 
-  worker-c36m225:
-    count: 11 #11
-    flavor: c1.c36m225d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: hard
-      mem_reserved_size: 2048
-    image: default
+  # worker-c36m225:
+  #   count: 11 #11
+  #   flavor: c1.c36m225d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: hard
+  #     mem_reserved_size: 2048
+  #   image: default
 
-  worker-c36m900:
-    count: 1 #1 it's a c1.c36m975d50 host with probably a faulty memory bank
-    flavor: c1.c36m900d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: soft
-      mem_reserved_size: 2048
-    image: default
+  # worker-c36m900:
+  #   count: 1 #1 it's a c1.c36m975d50 host with probably a faulty memory bank
+  #   flavor: c1.c36m900d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: soft
+  #     mem_reserved_size: 2048
+  #   image: default
 
-  worker-c36m975:
-    count: 8 #8
-    flavor: c1.c36m975d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: soft
-      mem_reserved_size: 2048
-    image: default
+  # worker-c36m975:
+  #   count: 8 #8
+  #   flavor: c1.c36m975d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: soft
+  #     mem_reserved_size: 2048
+  #   image: default
 
-  worker-c28m935:
-    count: 4 #4
-    flavor: c1.c28m935d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: soft
-      mem_reserved_size: 2048
-    image: default
+  # worker-c28m935:
+  #   count: 4 #4
+  #   flavor: c1.c28m935d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: soft
+  #     mem_reserved_size: 2048
+  #   image: default
 
-  worker-c28m875:
-    count: 2 #2
-    flavor: c1.c28m875d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: soft
-      mem_reserved_size: 2048
-    image: default
+  # worker-c28m875:
+  #   count: 2 #2
+  #   flavor: c1.c28m875d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: soft
+  #     mem_reserved_size: 2048
+  #   image: default
 
-  worker-c64m2:
-    count: 1 #1
-    flavor: c1.c60m1975d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    image: default
+  # worker-c64m2:
+  #   count: 1 #1
+  #   flavor: c1.c60m1975d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   image: default
 
-  worker-c120m225:
-    count: 12 #12
-    flavor: c1.c120m225d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: hard
-      mem_reserved_size: 2048
-    image: default
+  # worker-c120m225:
+  #   count: 12 #12
+  #   flavor: c1.c120m225d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: hard
+  #     mem_reserved_size: 2048
+  #   image: default
 
-  worker-c120m425:
-    count: 22
-    flavor: c1.c120m425d50
-    group: compute
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: hard
-      mem_reserved_size: 2048
-    image: default
+  # worker-c120m425:
+  #   count: 22
+  #   flavor: c1.c120m425d50
+  #   group: compute
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: hard
+  #     mem_reserved_size: 2048
+  #   image: default
 
   worker-c125m425:
-    count: 16 #16
+    count: 4 #16
     flavor: c1.c125m425d50
     group: compute
     docker: true
@@ -217,81 +217,81 @@ deployment:
       mem_reserved_size: 2048
     image: default
 
-  worker-c14m40g1:
-    count: 4 #4
-    flavor: g1.c14m40g1d50
-    group: compute_gpu
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: soft
-      mem_reserved_size: 1024
-    image: gpu
+  # worker-c14m40g1:
+  #   count: 4 #4
+  #   flavor: g1.c14m40g1d50
+  #   group: compute_gpu
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: soft
+  #     mem_reserved_size: 1024
+  #   image: gpu
 
-  worker-c8m40g1:
-    count: 4 #4
-    flavor: g1.c8m40g1d50
-    group: compute_gpu
-    docker: true
-    volume:
-      size: 1024
-      type: default
-    cgroups:
-      mem_limit_policy: soft
-      mem_reserved_size: 1024
-    image: gpu
+  # worker-c8m40g1:
+  #   count: 4 #4
+  #   flavor: g1.c8m40g1d50
+  #   group: compute_gpu
+  #   docker: true
+  #   volume:
+  #     size: 1024
+  #     type: default
+  #   cgroups:
+  #     mem_limit_policy: soft
+  #     mem_reserved_size: 1024
+  #   image: gpu
 
 
   # Trainings
   # These will overlap April 8-17
-  training-kmb6:
-    count: 1
-    flavor: c1.c28m225d50
-    start: 2024-03-01
-    end: 2024-05-17
-    group: training-kmb615
-    image: default
-  training-tp-m:
-    count: 2
-    flavor: c1.c28m225d50
-    start: 2024-03-26
-    end: 2024-04-17
-    group: training-tp-master1-chip-seq
-    image: default
-  training-geno:
-    count: 2
-    flavor: c1.c28m225d50
-    start: 2024-05-07
-    end: 2024-05-10
-    group: training-genome-assembly-2024
-    image: default
-  training-nort:
-    count: 2
-    flavor: c1.c28m225d50
-    start: 2024-06-07
-    end: 2024-06-07
-    group: training-northumbria-7jun24
-    image: default
-  training-joca:
-    count: 2
-    flavor: c1.c28m225d50
-    start: 2024-04-12
-    end: 2024-04-12
-    group: training-joca-epigenomics-24
-    image: default
-  training-woco:
-    count: 1
-    flavor: c1.c28m225d50
-    start: 2024-04-08
-    end: 2024-05-10
-    group: training-woco2024
-    image: default
-  training-e502:
-    count: 2
-    flavor: c1.c28m225d50
-    start: 2024-04-09
-    end: 2024-04-09
-    group: training-e5020-2024-04-09
-    image: default
+  # training-kmb6:
+  #   count: 1
+  #   flavor: c1.c28m225d50
+  #   start: 2024-03-01
+  #   end: 2024-05-17
+  #   group: training-kmb615
+  #   image: default
+  # training-tp-m:
+  #   count: 2
+  #   flavor: c1.c28m225d50
+  #   start: 2024-03-26
+  #   end: 2024-04-17
+  #   group: training-tp-master1-chip-seq
+  #   image: default
+  # training-geno:
+  #   count: 2
+  #   flavor: c1.c28m225d50
+  #   start: 2024-05-07
+  #   end: 2024-05-10
+  #   group: training-genome-assembly-2024
+  #   image: default
+  # training-nort:
+  #   count: 2
+  #   flavor: c1.c28m225d50
+  #   start: 2024-06-07
+  #   end: 2024-06-07
+  #   group: training-northumbria-7jun24
+  #   image: default
+  # training-joca:
+  #   count: 2
+  #   flavor: c1.c28m225d50
+  #   start: 2024-04-12
+  #   end: 2024-04-12
+  #   group: training-joca-epigenomics-24
+  #   image: default
+  # training-woco:
+  #   count: 1
+  #   flavor: c1.c28m225d50
+  #   start: 2024-04-08
+  #   end: 2024-05-10
+  #   group: training-woco2024
+  #   image: default
+  # training-e502:
+  #   count: 2
+  #   flavor: c1.c28m225d50
+  #   start: 2024-04-09
+  #   end: 2024-04-09
+  #   group: training-e5020-2024-04-09
+  #   image: default


### PR DESCRIPTION
In the first phase, only four workers of the flavor `c1.c125m425d50` must be spawned. This is just an initial phase to free the galaxy-queued jobs slowly.

Along with this, we will also get the other critical service VMs
1. upload/TUSd
2. 1 Jenkins silver worker (so these VMs can be created)
3. CVMFS (so jobs that depend on the CVMFS can actually run)

This PR disables all the resources except for one with the flavor  `c1.c125m425d50`, and only four VMS of this flavor can be spawned.