### PR TITLE
Fix missing volume in the IT node

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -60,10 +60,9 @@ deployment:
     group: interactive
     docker: true
     image: default
-
-  #   volume:
-  #     size: 1024
-  #     type: default
+    volume:
+      size: 1024
+      type: default
   # worker-c28m475:
   #   count: 10 #19
   #   flavor: c1.c28m475d50


### PR DESCRIPTION
Apologies for the oversight. I did not notice it was missing when I created the PR this morning. An unnecessary new line split the volume section from the VM, resulting in the oversight. 

I am not sure the script can dynamically mount it. I think the IT node needs to be recreated in order to attach a volume, as certain tasks need to run in the cloud-init step.