### PR TITLE
Migrate a few more to the new cloud

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -63,18 +63,18 @@ deployment:
     volume:
       size: 1024
       type: default
-  # worker-c28m475:
-  #   count: 10 #19
-  #   flavor: c1.c28m475d50
-  #   group: compute
-  #   docker: true
-  #   volume:
-  #     size: 1024
-  #     type: default
-  #   cgroups:
-  #     mem_limit_policy: hard
-  #     mem_reserved_size: 2048
-  #   image: default
+  worker-c28m475:
+    count: 10 #19
+    flavor: c1.c28m475d50
+    group: compute
+    docker: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: hard
+      mem_reserved_size: 2048
+    image: default
 
   # worker-c28m225:
   #   count: 0
@@ -190,18 +190,18 @@ deployment:
   #     mem_reserved_size: 2048
   #   image: default
 
-  # worker-c120m425:
-  #   count: 22
-  #   flavor: c1.c120m425d50
-  #   group: compute
-  #   docker: true
-  #   volume:
-  #     size: 1024
-  #     type: default
-  #   cgroups:
-  #     mem_limit_policy: hard
-  #     mem_reserved_size: 2048
-  #   image: default
+  worker-c120m425:
+    count: 18 #22
+    flavor: c1.c120m425d50
+    group: compute
+    docker: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: hard
+      mem_reserved_size: 2048
+    image: default
 
   worker-c125m425:
     count: 16 #16


### PR DESCRIPTION
Notes:
1. I have moved these to the new cloud (not through the CI), and they are connected to Galaxy's job scheduler. 
2. The new cloud credentials were added to Jenkins, and the `VGCN-infrastructure` Jenkins project was reconfigured to use the new credentials.
3. IT flavor VMs have still not been migrated, so the Jenkins project has been temporarily disabled; otherwise, it will fail.

We still have to migrate a lot of the resources, and there are several issues:
1. Some servers did not come back online after the shutdown of the servers due to the generator testing
2. Migrating GPU VMs will take some time, as the new OpenStack version changed the GPU passthrough, and the cloud team could not test this beforehand.
3. Several VMs that come online are broken due to some underlying hardware issue. 

Migration will be slow; however, now all the compute VMs connected to Galaxy are running in the new cloud except for the 1 IT VM.