### PR TITLE
redirect training resources to galaxy as compute nodes for the time being

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -76,18 +76,21 @@ deployment:
       mem_reserved_size: 2048
     image: default
 
-  # worker-c28m225:
-  #   count: 0
-  #   flavor: c1.c28m225d50
-  #   group: compute_test
-  #   docker: true
-  #   volume:
-  #     size: 1024
-  #     type: default
-  #   cgroups:
-  #     mem_limit_policy: hard
-  #     mem_reserved_size: 2048
-  #   image: default
+  # 16.4.2024: Enable this temporarily. This flavor is dedicated for training VMs,
+  # and since we do not have enough compute for Galaxy in the new cloud yet, let's redirect the
+  # training VMs resources to the Galaxy and deploy them as compute nodes for now.
+  worker-c28m225:
+    count: 7 #0
+    flavor: c1.c28m225d50
+    group: compute # compute_test
+    docker: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: hard
+      mem_reserved_size: 2048
+    image: default
 
   # worker-c36m100:
   #   count: 26 #32


### PR DESCRIPTION
Let's enable this temporarily. This flavor is dedicated for training VMs in general, and since we do not have enough compute for Galaxy in the new cloud yet, let's redirect the training VMs resources to the Galaxy and deploy them as compute nodes for now.