### PR TITLE
cloud migration: Add locally/manually deployed changes

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -19,7 +19,7 @@ pubkeys:
 graceful: false
 
 nodes_inventory:
-  c1.c28m225d50: 7
+  c1.c28m225d50: 5 #(16.04.2024: RZ swapped the underlying servers for a 4 in 1 node and this will be of a different flavor and we need to wait to get the hardware)
   c1.c28m475d50: 19
   c1.c36m100d50: 32
   c1.c36m225d50: 11
@@ -64,7 +64,7 @@ deployment:
       size: 1024
       type: default
   worker-c28m475:
-    count: 10 #19
+    count: 19 #19
     flavor: c1.c28m475d50
     group: compute
     docker: true
@@ -92,57 +92,57 @@ deployment:
       mem_reserved_size: 2048
     image: default
 
-  # worker-c36m100:
-  #   count: 26 #32
-  #   flavor: c1.c36m100d50
-  #   group: compute
-  #   docker: true
-  #   volume:
-  #     size: 1024
-  #     type: default
-  #   cgroups:
-  #     mem_limit_policy: hard
-  #     mem_reserved_size: 2048
-  #   image: default
+  worker-c36m100:
+    count: 1 #26 #32
+    flavor: c1.c36m100d50
+    group: compute
+    docker: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: hard
+      mem_reserved_size: 2048
+    image: default
 
-  # worker-c36m225:
-  #   count: 11 #11
-  #   flavor: c1.c36m225d50
-  #   group: compute
-  #   docker: true
-  #   volume:
-  #     size: 1024
-  #     type: default
-  #   cgroups:
-  #     mem_limit_policy: hard
-  #     mem_reserved_size: 2048
-  #   image: default
+  worker-c36m225:
+    count: 8 #11
+    flavor: c1.c36m225d50
+    group: compute
+    docker: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: hard
+      mem_reserved_size: 2048
+    image: default
 
-  # worker-c36m900:
-  #   count: 1 #1 it's a c1.c36m975d50 host with probably a faulty memory bank
-  #   flavor: c1.c36m900d50
-  #   group: compute
-  #   docker: true
-  #   volume:
-  #     size: 1024
-  #     type: default
-  #   cgroups:
-  #     mem_limit_policy: soft
-  #     mem_reserved_size: 2048
-  #   image: default
+  worker-c36m900:
+    count: 1 #1 it's a c1.c36m975d50 host with probably a faulty memory bank
+    flavor: c1.c36m900d50
+    group: compute
+    docker: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: soft
+      mem_reserved_size: 2048
+    image: default
 
-  # worker-c36m975:
-  #   count: 8 #8
-  #   flavor: c1.c36m975d50
-  #   group: compute
-  #   docker: true
-  #   volume:
-  #     size: 1024
-  #     type: default
-  #   cgroups:
-  #     mem_limit_policy: soft
-  #     mem_reserved_size: 2048
-  #   image: default
+  worker-c36m975:
+    count: 7 #8
+    flavor: c1.c36m975d50
+    group: compute
+    docker: true
+    volume:
+      size: 1024
+      type: default
+    cgroups:
+      mem_limit_policy: soft
+      mem_reserved_size: 2048
+    image: default
 
   # worker-c28m935:
   #   count: 4 #4


### PR DESCRIPTION
This PR syncs my local changes, which I have manually deployed to the new cloud.

We still have no ETA for the GPU VMs and n36 nodes. 

GPU VMs might take some time as they have not yet tested anything related to this, and the new OpenStack version seems to have changed the passthrough.

n36 nodes have issues, and RZ is working on bringing this back online.