### PR TITLE
return the training resources to TIaaS

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -76,11 +76,8 @@ deployment:
       mem_reserved_size: 2048
     image: default
 
-  # 16.4.2024: Enable this temporarily. This flavor is dedicated for training VMs,
-  # and since we do not have enough compute for Galaxy in the new cloud yet, let's redirect the
-  # training VMs resources to the Galaxy and deploy them as compute nodes for now.
   worker-c28m225:
-    count: 5
+    count: 0
     flavor: c1.c28m225d50
     group: compute # compute_test
     docker: true


### PR DESCRIPTION
The VMs were drained and removed from the new cloud. We will now have 5 VMs that can be distributed to TIaaS requests.