### PR TITLE
Add Training kmb613-2

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -292,3 +292,9 @@ deployment:
     start: 2024-12-02
     end: 2024-12-06
     group: training-ki-bioinfo-dna-2024
+  training-kmb6:
+    count: 1
+    flavor: c1.c28m225d50
+    start: 2024-10-28
+    end: 2024-12-19
+    group: training-kmb613-2


### PR DESCRIPTION
These are the conflicting trainings during Nov 14 and 15:
https://github.com/usegalaxy-eu/vgcn-infrastructure/blob/3db0425bbd56bffeee287a91ffb263ffb3f62d8f/resources.yaml#L201C1-L202
https://github.com/usegalaxy-eu/vgcn-infrastructure/blob/3db0425bbd56bffeee287a91ffb263ffb3f62d8f/resources.yaml#L259-L260
https://github.com/usegalaxy-eu/vgcn-infrastructure/blob/3db0425bbd56bffeee287a91ffb263ffb3f62d8f/resources.yaml#L207-L208
https://github.com/usegalaxy-eu/vgcn-infrastructure/blob/3db0425bbd56bffeee287a91ffb263ffb3f62d8f/resources.yaml#L271-L272
https://github.com/usegalaxy-eu/vgcn-infrastructure/blob/3db0425bbd56bffeee287a91ffb263ffb3f62d8f/resources.yaml#L253-L254
https://github.com/usegalaxy-eu/vgcn-infrastructure/blob/3db0425bbd56bffeee287a91ffb263ffb3f62d8f/resources.yaml#L201-L202

1. `sacc` should probably get `1`(?)
2. `epfl` could maybe be reduced to `1` 
3. `bma2` runs for 3 months, maybe we could set the count to `0` for these two days.