### PR TITLE
Remove old Broadwell nodes from inventory

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -20,10 +20,10 @@ graceful: false
 
 # 18/6/2024: Updated the max number of possible workers
 nodes_inventory:
-  c1.c28m225d50: 5 #(16.04.2024: RZ swapped the underlying servers for a 4 in 1 node and this will be of a different flavor and we need to wait to get the hardware)
+  c1.c28m225d50: 0 # (18.12.2024: decommisioned) (16.04.2024: RZ swapped the underlying servers for a 4 in 1 node and this will be of a different flavor and we need to wait to get the hardware)
   c1.c28m475d50: 19
-  c1.c36m100d50: 30
-  c1.c36m225d50: 15
+  c1.c36m100d50: 0
+  c1.c36m225d50: 0
   c1.c36m900d50: 1
   c1.c36m975d50: 8
   c1.c60m1975d50: 1
@@ -43,7 +43,7 @@ deployment:
   #   image: default
 
   worker-interactive:
-    count: 2 #3
+    count: 0 # decommisioned hardware
     flavor: c1.c36m100d50
     group: interactive
     docker: true
@@ -72,7 +72,7 @@ deployment:
     image: default
 
   worker-c36m100:
-    count: 25
+    count: 0
     flavor: c1.c36m100d50
     group: compute
     docker: true
@@ -82,7 +82,7 @@ deployment:
     image: default
 
   worker-c36m225:
-    count: 14
+    count: 0
     flavor: c1.c36m225d50
     group: compute
     docker: true


### PR DESCRIPTION
The non-high-mem and non-gpu Intel Broadwell nodes are decommissioned now.
(we can also fully remove the flavor soon – it will be in git still)