### PR TITLE
add training htsd

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -144,7 +144,7 @@ deployment:
     image: default
 
   worker-c120m205:
-    count: 10
+    count: 9
     flavor: c1.c120m205d50
     group: compute
     docker: true

--- a/resources.yaml
+++ b/resources.yaml
@@ -194,15 +194,15 @@ deployment:
     image: gpu
 
   # Trainings
-  training-gdaw:
-    count: 1
-    flavor: c1.c120m205d50
-    start: 2024-12-10
-    end: 2024-12-30
-    group: training-gdawg2024
   training-ga-f:
     count: 1
     flavor: c1.c120m205d50 #Maybe change?
     start: 2025-02-17
     end: 2025-03-01
     group: training-ga-fcen-uba-2025
+  training-htsd:
+    count: 1
+    flavor: c1.c120m205d50
+    start: 2025-01-22
+    end: 2025-01-29
+    group: training-htsd

--- a/resources.yaml
+++ b/resources.yaml
@@ -52,7 +52,7 @@ deployment:
       size: 1024
       type: default
   worker-c28m475:
-    count: 25
+    count: 19
     flavor: c1.c28m475d50
     group: compute
     docker: true


### PR DESCRIPTION
for the upcoming trainings, I would use `c120m205` VMs, the `c36m100` flavor might be too small and in January there is max 1 training at a time. I would drain a c120m205 node for htsd next week.