### PR TITLE
enable rest 13 VMs of flavor c1.c186m1450d50

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -196,7 +196,7 @@ deployment:
 
   # 17/01/2025: New Genoa nodes are added to the cloud
   worker-c186m1450:
-    count: 2 #17
+    count: 15 #17
     flavor: c1.c186m1450d50
     group: compute
     docker: true


### PR DESCRIPTION
The first two test VMs were deployed successfully so enabling the rest 13 (2 more nodes will be added later). 