### PR TITLE
drain a compute node and assign it to the TIaaS session

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -145,7 +145,7 @@ deployment:
     image: default
 
   worker-c120m205:
-    count: 8
+    count: 7
     flavor: c1.c120m205d50
     group: compute
     docker: true


### PR DESCRIPTION
As requested in the OPs chat, I have drained a `c120m205` flavor node, deleted it, and readjusted the assignments to allocate it for tomorrow's training session for `training-htsd`. 