### PR TITLE
Double up BGE training resources

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -224,8 +224,8 @@ deployment:
     start: 2025-01-22
     end: 2025-01-29
     group: training-htsd
-  training-bge-:
-    count: 1
+  training-bge-lodz:
+    count: 2
     flavor: c1.c120m205d50
     start: 2025-02-05
     end: 2025-02-09


### PR DESCRIPTION
They are planning to run resource-intensive tools and expect at least 25 participants.

@SaimMomin12 as requested. 