### PR TITLE
Update training resource for training-bm327-workshop-1

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -196,7 +196,7 @@ deployment:
 
   # 17/01/2025: New Genoa nodes are added to the cloud
   worker-c186m1450:
-    count: 15 #17
+    count: 14 #17
     flavor: c1.c186m1450d50
     group: compute
     docker: true
@@ -268,7 +268,7 @@ deployment:
     group: training-genome-assembly-phys
   training-bm32:
     count: 1
-    flavor: c1.c120m205d50
+    flavor: c1.c186m1450d50
     start: 2025-02-21
     end: 2025-02-21
     group: training-bm327-workshop-1


### PR DESCRIPTION
Its a one day training session and they expect 70 attendees. So draining a big node.

@mira-miracoli drained it. I will now delete a node and try to deploy it.