### PR TITLE
added rcb0300-2025 training

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -248,3 +248,9 @@ deployment:
     start: 2025-03-17
     end: 2025-03-20
     group: training-tim-bioimage-tools
+  training-rcb0:
+    count: 1
+    flavor: c1.c120m205d50
+    start: 2025-03-10
+    end: 2025-03-14
+    group: training-rcb0300-2025


### PR DESCRIPTION
Reminder: Drain two 120m205 VMs before training starts (March 16)