### PR TITLE
reduce the available resource count for the flavor c28m475

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -21,7 +21,7 @@ graceful: false
 # 18/6/2024: Updated the max number of possible workers
 nodes_inventory:
   c1.c28m225d50: 5 #(16.04.2024: RZ swapped the underlying servers for a 4 in 1 node and this will be of a different flavor and we need to wait to get the hardware)
-  c1.c28m475d50: 19
+  c1.c28m475d50: 13
   c1.c36m100d50: 30
   c1.c36m225d50: 15
   c1.c36m900d50: 1
@@ -53,7 +53,7 @@ deployment:
       size: 1024
       type: default
   worker-c28m475:
-    count: 19
+    count: 13
     flavor: c1.c28m475d50
     group: compute
     docker: true


### PR DESCRIPTION
I have drained and removed 6 VMs of this flavor upon RZ's request. RZ will repurpose the underlying nodes for other purposes.