### PR TITLE
update autofs mount config template to include the new misc and cache shares

### DIFF
--- a/userdata.yaml.j2
+++ b/userdata.yaml.j2
@@ -40,6 +40,12 @@ write_files:
       {% for mount in jwd.values() -%}
         {{ mount.name }}	-{{ mount.nfs_options | join(',') }}	{{ mount.export }}
       {% endfor %}
+      {% for mount in cache.values() -%}
+        {{ mount.name }}	-{{ mount.nfs_options | join(',') }}	{{ mount.export }}
+      {% endfor %}
+      {% for mount in misc.values() -%}
+        {{ mount.name }}	-{{ mount.nfs_options | join(',') }}	{{ mount.export }}
+      {% endfor %}
     owner: root:root
     path: /etc/auto.data
     permissions: "0644"


### PR DESCRIPTION
We have new NFS shares `cache06` and `misc06` with keys [cache](https://github.com/usegalaxy-eu/mounts/blob/main/mountpoints.yml#L461-L470) and [misc](https://github.com/usegalaxy-eu/mounts/blob/main/mountpoints.yml#L472-L481). There will be a few more `cache` and `misc` shares soon from the new ZFS servers. 

This PR updates the templates in the userdata to include these new shares.