### PR TITLE
training was split in 2 individual tiaas events

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -207,8 +207,8 @@ deployment:
 
   # Trainings
   training-mcbb:
-    count: 1
+    count: 2
     flavor: c1.c120m205d50
     start: 2025-03-25
-    end: 2025-04-15
+    end: 2025-03-25
     group: training-mcbbi-aeg-2025


### PR DESCRIPTION
For only 1 day I would give 2 servers, because we have the capacity and the training uses OrthoFinder, which takes 30G ram