### PR TITLE
TIaaS: Increase resources for mbru2025 training.

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -145,7 +145,7 @@ deployment:
     image: default
 
   worker-c120m205:
-    count: 7
+    count: 6
     flavor: c1.c120m205d50
     group: compute
     docker: true
@@ -207,7 +207,7 @@ deployment:
 
   # Trainings
   training-mbru:
-    count: 1
+    count: 2
     flavor: c1.c120m205d50
     start: 2025-05-19
     end: 2025-05-23


### PR DESCRIPTION
The trainer has requested additional resources since they have 100+ participants. I hope 2 VMs might be good enough. On the 20th evening, drain and delete one of the `c120m205d50` compute nodes so the other trainings can have their dedicated resources. 

