### PR TITLE
fix false negative results when determining available training nodes

### DIFF
--- a/check_conflicts.py
+++ b/check_conflicts.py
@@ -5,11 +5,12 @@ def check_conflicts(file_path):
     with open(file_path, "r") as file:
         data = yaml.safe_load(file)
     df = pd.DataFrame(data["deployment"]).T
-    df["node"] = df.index
+    df.index.name = "resource_group"
+    df.reset_index(inplace=True)
 
     # Separate workers and trainings
-    worker_df = df[~df["node"].str.startswith("training-")]
-    training_df = df[df["node"].str.startswith("training-")]
+    worker_df = df[~df["resource_group"].str.startswith("training-")]
+    training_df = df[df["resource_group"].str.startswith("training-")]
 
     # Calculate available nodes per flavor
     worker_counts = worker_df.groupby("flavor")["count"].sum().to_dict()
@@ -18,21 +19,20 @@ def check_conflicts(file_path):
     conflicts = []
     if not training_df.empty:
         # Counting frequency of training nodes per day
-        training_df = training_df.reset_index()
         training_df["date"] = training_df.apply(
             lambda x: pd.date_range(start=x["start"], end=x["end"]), axis=1
         )
         training_df = training_df.explode("date")
         grouped = training_df.groupby(["flavor", "date"]).agg(
-            {"count": "sum", "node": "unique"}
+            {"count": "sum", "resource_group": "unique"}
         ).reset_index()
         # Check requested training nodes against available nodes
         grouped["available_nodes"] = grouped["flavor"].map(available_nodes).fillna(0)
         grouped["conflict"] = grouped["count"] > grouped["available_nodes"]
-        grouped["node"] = grouped["node"].apply(lambda x: ", ".join(x))
+        grouped["resource_group"] = grouped["resource_group"].apply(lambda x: ", ".join(x))
         for _, row in grouped[grouped["conflict"]].iterrows():
             conflicts.append(
-                f"Conflict for {row['flavor']} on {row['date'].strftime('%Y-%m-%d')} with {row['count']} training nodes requested but only {row['available_nodes']} available nodes. Conflicted trainings: {row['node']}."
+                f"Conflict for {row['flavor']} on {row['date'].strftime('%Y-%m-%d')} with {row['count']} training nodes requested but only {row['available_nodes']} available nodes. Conflicted trainings: {row['resource_group']}."
             )
 
     if conflicts:


### PR DESCRIPTION
`check_conflicts.py` produces false negative results  (i.e. no conflicts) because it determines the number of available nodes solely from the node numbers of `node_inventory` and does not subtract the numbers of `deployment` worker nodes from this. As a result, the number of nodes available for TIaaS are too high.

The updated version takes this into account and calculates the actual number of nodes available by subtracting the number of worker nodes from the number of inventory nodes.

(also described here: https://github.com/usegalaxy-eu/vgcn-infrastructure/issues/390)
