### PR TITLE
Retire VGCN cloud workers

### DIFF
--- a/resources.yaml
+++ b/resources.yaml
@@ -35,14 +35,6 @@ deployment:
   #     type: default
   #   image: default
 
-  # VGCN Cloud Workers
-  worker-c62m240:
-    count: 6
-    docker: true
-    flavor: c1.c62m240d50
-    image: default
-    group: compute
-
   # Trainings
   training-fabi8391:
     count: 2


### PR DESCRIPTION
Most of the compute infrastructure has been moved to bare-metal nodes. These six nodes provide little extra performance for a large management effort.

Retire them as planned. Closes https://github.com/usegalaxy-eu/issues/issues/846.